### PR TITLE
Improve encoding and data handling capabilities

### DIFF
--- a/xar/src/main/java/com/sprylab/xar/XarEntry.java
+++ b/xar/src/main/java/com/sprylab/xar/XarEntry.java
@@ -125,6 +125,13 @@ public class XarEntry {
     }
 
     /**
+     * @return the {@link Encoding} of this entry
+     */
+    public Encoding getEncoding() {
+        return encoding;
+    }
+
+    /**
      * @return the ID of this entry
      */
     public String getId() {
@@ -259,6 +266,31 @@ public class XarEntry {
             default:
                 throw new UnsupportedEncodingException("Encoding not supported: " + encoding.name());
         }
+    }
+
+    /**
+     * Gets access to the underlying byte data of this entry.
+     * <p>
+     * This allows direct streaming from the archive file without extracting and writing the corresponding file to disk beforehand.
+     * If the data is encoded (see {@link Encoding}), then it won't be decompressed while reading from the returned {@link Source}.     
+     * <p>
+     * When trying to call this method on an directory entry (i.e. {@link #isDirectory()} returns {@code true}),
+     * an {@link IllegalStateException} is thrown.
+     *
+     * @return the {@link Source} to read from
+     * @throws IOException when an I/O error occurred while reading
+     */
+    public Source getRawSource() throws IOException {
+        if (isDirectory) {
+            throw new IllegalStateException("Cannot retrieve source for entries of type directory.");
+        }
+
+        if (encoding == null) {
+            // file is empty
+            return new Buffer();
+        }
+
+        return xarSource.getRange(offset, length);
     }
 
     /**

--- a/xar/src/main/java/com/sprylab/xar/toc/model/EncodingEnumTransform.java
+++ b/xar/src/main/java/com/sprylab/xar/toc/model/EncodingEnumTransform.java
@@ -13,7 +13,8 @@ public class EncodingEnumTransform implements Transform<Encoding> {
 
     public static final String MIME_TYPE_GZIP = "application/x-gzip";
 
-    public static final String MIME_TYPE_BZIP2 = "application/x-bzip";
+    public static final String MIME_TYPE_BZIP2_1 = "application/x-bzip";
+    public static final String MIME_TYPE_BZIP2_2 = "application/x-bzip2";
 
     @Override
     public Encoding read(final String value) throws Exception {
@@ -23,7 +24,7 @@ public class EncodingEnumTransform implements Transform<Encoding> {
         if (value.equals(MIME_TYPE_GZIP)) {
             return Encoding.GZIP;
         }
-        if (value.equals(MIME_TYPE_BZIP2)) {
+        if (value.equals(MIME_TYPE_BZIP2_1) || value.equals(MIME_TYPE_BZIP2_2)) {
             return Encoding.BZIP2;
         }
         return Encoding.NONE;
@@ -35,7 +36,7 @@ public class EncodingEnumTransform implements Transform<Encoding> {
             case GZIP:
                 return MIME_TYPE_GZIP;
             case BZIP2:
-                return MIME_TYPE_BZIP2;
+                return MIME_TYPE_BZIP2_1;
             case NONE:
                 return MIME_TYPE_OCTET_STREAM;
             default:


### PR DESCRIPTION
Hi! 

I would like to provide a few minor improvements that make life easier if data is compressed with unsupported approaches. This also allows use of other libraries for decompression.

There is another MIME type for BZIP2. This PR improves EncodingEnumTransform so that this is recognized correctly.

It's great to have a getter for the encoding of XarEntry. Then one can decide what to do with the underlying data without trial and error.

By providing access to raw data of the XarEntry, the stream can be handled by other libraries as well.

Cheers,
Markus