### PR TITLE
Fixed jpackage error for Java 9 and later

### DIFF
--- a/xar/pom.xml
+++ b/xar/pom.xml
@@ -121,7 +121,7 @@
         <profile>
             <id>UntilJava8</id>
             <activation>
-              <jdk>[1.0, 1.9)</jdk>
+              <activeByDefault>true</activeByDefault>
             </activation>
             
             <dependencies>

--- a/xar/pom.xml
+++ b/xar/pom.xml
@@ -51,13 +51,6 @@
             <version>${okio.version}</version>
         </dependency>
 
-        <!-- jOOU -->
-        <dependency>
-            <groupId>org.jooq</groupId>
-            <artifactId>joou-java-6</artifactId>
-            <version>${joou.version}</version>
-        </dependency>
-
         <!-- SLF4J -->
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -123,5 +116,39 @@
             </plugin>
         </plugins>
     </build>
+    
+    <profiles>
+        <profile>
+            <id>UntilJava8</id>
+            <activation>
+              <jdk>[1.0, 1.9)</jdk>
+            </activation>
+            
+            <dependencies>
+                <!-- jOOU -->
+                <dependency>
+                    <groupId>org.jooq</groupId>
+                    <artifactId>joou-java-6</artifactId>
+                    <version>${joou.version}</version>
+                </dependency>
+            </dependencies>
+            
+        </profile>
+                <profile>
+            <id>AfterJava8</id>
+            <activation>
+              <jdk>[1.9,)</jdk>
+            </activation>
+            
+            <dependencies>
+                <!-- jOOU -->
+                <dependency>
+                    <groupId>org.jooq</groupId>
+                    <artifactId>joou</artifactId>
+                    <version>${joou.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
#16 

Fixed by introducing two profiles with different dependencies.
1. Profile: Activated by default and has a dependency to the old joou-java-6 which should be used up to and including Java 8
2. Profile: Activated if Java 9 or later is detected as build environment (by using JAVA_HOME environment variable) and has as dependency joou which should be used for Java 9 or later